### PR TITLE
Windows service, fix relative paths

### DIFF
--- a/dist/windows/service_restart.bat
+++ b/dist/windows/service_restart.bat
@@ -1,0 +1,13 @@
+@echo off
+title ByeDPI - Restart Service
+
+echo This script should be run with administrator privileges.
+echo Right click - run as administrator.
+echo Press any key if you're running it as administrator.
+pause
+
+set svc_name="ByeDPI"
+
+sc stop %svc_name%
+sc start %svc_name%
+pause

--- a/win_service.c
+++ b/win_service.c
@@ -1,6 +1,5 @@
 #include "win_service.h"
-#include <minwindef.h>
-#include <winsvc.h>
+#include <windows.h>
 
 #define SERVICE_NAME "ByeDPI"
 
@@ -29,6 +28,15 @@ void service_ctrl_handler(DWORD request)
 
 void service_main(int argc __attribute__((unused)), char *argv[] __attribute__((unused)))
 {
+    // Current working directory for services is %WinDir%\System32, this breaks 
+    // relative paths. Set working directory to the directory of the executable file.
+    char file_name[_MAX_PATH];
+    GetModuleFileNameA(NULL, file_name, sizeof(file_name));
+    char working_dir[_MAX_PATH], _tmp[_MAX_DIR];
+    _splitpath_s(file_name, working_dir, _MAX_DRIVE, _tmp, _MAX_DIR, NULL, 0, NULL, 0);
+    strcat_s(working_dir, sizeof(working_dir), _tmp);
+    SetCurrentDirectoryA(working_dir);
+
     ServiceStatus.dwServiceType = SERVICE_WIN32_OWN_PROCESS; 
     ServiceStatus.dwCurrentState = SERVICE_RUNNING;
     ServiceStatus.dwControlsAccepted = SERVICE_ACCEPT_STOP | SERVICE_ACCEPT_SHUTDOWN;


### PR DESCRIPTION
При запуске программы в качестве службы Windows, ее рабочая директория устанавливается в `%WinDir%\System32`, что ломает относительные пути. Например, чтобы работало `--hosts list.txt` нужно или поместить `list.txt` в `%WinDir%\System32` или указать полный путь `--hosts "C:\Program Files\ByeDPI\list.txt"`. Этот PR меняет это поведение, устанавливая рабочую директорию в ту в которой находится исполняемый файл.

~~Из-за `-lshlwapi` исполняемый файл поправился на 90кб (после strip, всего на 17кб).~~

Также добавил `service_restart.bat`, для быстрого перезапуска сервиса, например после редактирования `list.txt`.