### PR TITLE
Fix usage of some misaligned pointers

### DIFF
--- a/extend.c
+++ b/extend.c
@@ -90,7 +90,7 @@ int mode_add_get(struct sockaddr_ina *dst, int m)
 }
 
 
-inline bool check_port(uint16_t *p, struct sockaddr_in6 *dst)
+static inline bool check_port(uint16_t *p, struct sockaddr_in6 *dst)
 {
     return (dst->sin6_port >= p[0] 
             && dst->sin6_port <= p[1]);

--- a/packets.c
+++ b/packets.c
@@ -137,10 +137,14 @@ int change_tls_sni(const char *host, char *buffer, size_t bsize)
             || free_sz < diff) {
         return -1;
     }
-    *(uint16_t *)(sni + 2) = htons(old_sz + diff + 5);
-    *(uint16_t *)(sni + 4) = htons(old_sz + diff + 3);
-    *(uint16_t *)(sni + 7) = htons(old_sz + diff);
-    *(uint16_t *)(pad + 2) = htons(free_sz - diff);
+    uint16_t htons_sni2 = htons(old_sz + diff + 5);
+    uint16_t htons_sni4 = htons(old_sz + diff + 3);
+    uint16_t htons_sni7 = htons(old_sz + diff);
+    uint16_t htons_pad2 = htons(old_sz - diff);
+    memcpy(sni + 2, &htons_sni2, sizeof(htons_sni2));
+    memcpy(sni + 4, &htons_sni4, sizeof(htons_sni4));
+    memcpy(sni + 7, &htons_sni7, sizeof(htons_sni7));
+    memcpy(pad + 2, &htons_pad2, sizeof(htons_pad2));
     
     char *host_end = sni + 9 + old_sz;
     int oth_sz = bsize - (sni_offs + 9 + old_sz);
@@ -410,7 +414,11 @@ int part_tls(char *buffer, size_t bsize, ssize_t n, long pos)
     memmove(buffer + 5 + pos + 5, buffer + 5 + pos, n - (5 + pos));
     memcpy(buffer + 5 + pos, buffer, 3);
     
-    *(uint16_t *)(buffer + 3) = htons(pos);
-    *(uint16_t *)(buffer + 5 + pos + 3) = htons(r_sz - pos);
+    uint16_t htons_pos = htons(pos);
+    memcpy(buffer + 3, &htons_pos, sizeof(htons_pos));
+    
+    uint16_t htons_rsz_pos = htons(r_sz - pos);
+    memcpy(buffer + 5 + pos + 3, &htons_rsz_pos, sizeof(htons_rsz_pos));
+    
     return 5;
 }

--- a/proxy.c
+++ b/proxy.c
@@ -274,7 +274,7 @@ int s5_get_addr(char *buffer, size_t n,
                 addr->in6.sin6_addr = r->i6;
             }
     }
-    addr->in.sin_port = *(uint16_t *)&buffer[o - 2];
+    memcpy(&addr->in.sin_port, &buffer[o - 2], sizeof(uint16_t));
     return o;
 }
 


### PR DESCRIPTION
When byedpi compiled with clang sanitizers:
```
 CC=clang CFLAGS="-Wno-unused -fno-omit-frame-pointer -fsanitize=undefined,address -g3" make
 ```
 And then tested with most of simple options:
 ```
  ./ciadpi -i 127.0.0.1 -p 8080 --timeout 10 --split 4 --fake 1 --tlsrec 1 --disorder 1 -n "gnu.org" --md5sig --udp-fake 1 --oob 1
```
It it gets runtime errors of misaligned addresses usage:
```
packets.c:142:5: runtime error: store to misaligned address 0x56220541ecb7 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x56220541ecb7: note: pointer points here
 0c 00 0a 00 00  11 77 77 77 2e 77 69 6b  69 70 65 64 69 61 2e 6f  72 67 00 0b 00 04 03 00  01 02 00
             ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior packets.c:142:5 in
packets.c:143:5: runtime error: store to misaligned address 0x56220541ed77 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x56220541ed77: note: pointer points here
 fb 0e 00 15 00  ac 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00
             ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior packets.c:143:5 in
sni: gnu.org
packets.c:413:5: runtime error: store to misaligned address 0x629000000203 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x629000000203: note: pointer points here
 00  16 03 01 04 77 01 16 03  01 03 03 00 04 73 03 03  d7 f5 ad b9 b6 4e cc 8b  85 85 a0 b0 8a 77 af
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior packets.c:413:5 in
packets.c:414:5: runtime error: store to misaligned address 0x629000000209 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x629000000209: note: pointer points here
 01 16 03  01 03 03 00 04 73 03 03  d7 f5 ad b9 b6 4e cc 8b  85 85 a0 b0 8a 77 af 67  96 cb 8e 5b 70
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior packets.c:414:5 in
split cancel: pos=4-1, n=1153
proxy.c:277:25: runtime error: load of misaligned address 0x629000000219 for type 'uint16_t' (aka 'unsigned short'), which requires 2 byte alignment
0x629000000219: note: pointer points here
 2e 63 6f  6d 01 bb 6f 3d 86 cf 89  94 ac cd df db fe e6 d2  2b e6 58 19 c9 c6 e3 d0  82 99 fc e8 f9
              ^
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior proxy.c:277:25 in ...
 ```
 
 These errors are UB and can make problems on some platforms. 
 This PR fixes usage of found misaligned pointers with memcpy.
 Changes tested on x86_64 and armv7 Linux and no runtime errors were produced.
 
 The project probably has much more such usages but I fixed only which clang found.

 