### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,25 @@
 TARGET = ciadpi
-CC ?= gcc
-CFLAGS += -std=c99 -O2 -D_XOPEN_SOURCE=500 
-SOURCES = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
-WIN_SOURCES = win_service.c
 
-all:
-	$(CC) $(CFLAGS) $(SOURCES) -I . -o $(TARGET)
+CPPFLAGS = -D_XOPEN_SOURCE=500
+CFLAGS += -I. -std=c99 -Wall -Wno-unused -O2
+WIN_LDFLAGS = -lws2_32 -lmswsock
 
-windows:
-	$(CC) $(CFLAGS) $(SOURCES) $(WIN_SOURCES) -I . -lws2_32 -lmswsock -o $(TARGET).exe
+SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
+WIN_SRC = win_service.c
+
+OBJ = $(SRC:.c=.o)
+WIN_OBJ = $(WIN_SRC:.c=.o)
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CC) -o $(TARGET) $(OBJ) $(LDFLAGS)
+
+windows: $(OBJ) $(WIN_OBJ)
+	$(CC) -o $(TARGET).exe $(OBJ) $(WIN_OBJ) $(WIN_LDFLAGS)
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 clean:
-	rm -f $(TARGET) *.o
+	rm -f $(TARGET) $(TARGET).exe $(OBJ) $(WIN_OBJ)


### PR DESCRIPTION
Improves Makefile:
1. Checking if CC is empty does not work because it defaults to "cc", which is linked to gcc on most systems anyway. So do not set it at all.
https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
2. Splits objects compiling which allows parallel building.
3. Recompile only changed files.
4. Clean only potentially compiled object files, not all (*.o).

Tested with both GNU make and BSD make on Linux.
Windows build tested with cross comping from Linux: ```CC=x86_64-w64-mingw32-gcc make windows```