### PR TITLE
Handle SIGTERM along with SIGINT

### DIFF
--- a/proxy.c
+++ b/proxy.c
@@ -974,6 +974,7 @@ int run(struct sockaddr_ina *srv)
         uniperror("signal SIGPIPE!");
     #endif
     signal(SIGINT, on_cancel);
+    signal(SIGTERM, on_cancel);
     
     int fd = listen_socket(srv);
     if (fd < 0) {


### PR DESCRIPTION
According to the definition and practice, SIGINT is good to stop a console app (Ctrl-C), while SIGTERM is designed to gracefully stop a background service.

[GNU](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html):
SIGTERM: It is the normal way to _politely ask a program_ to terminate. The shell command kill generates SIGTERM by default.
SIGINT: The SIGINT (“program interrupt”) signal is sent _when the user types_ the INTR character (normally C-c)

[C/C++](https://en.cppreference.com/w/c/program/SIG_types):
SIGTERM: termination _request, sent to the program_
SIGINT: external interrupt, _usually initiated by the user_

The main use of `ciadpi` is a background service.