### PR TITLE
Delete broken event, log "pull is full" error

### DIFF
--- a/conev.c
+++ b/conev.c
@@ -4,18 +4,20 @@
 #include <string.h>
 #include <limits.h>
 #include <assert.h>
+#include "error.h"
 
 
 struct poolhd *init_pool(int count)
 {
     struct poolhd *pool = calloc(sizeof(struct poolhd), 1);
     if (!pool) {
+        uniperror("init pool");
         return 0;
     }
     pool->max = count;
     pool->count = 0;
     pool->iters = 0;
-    
+
     #ifndef NOEPOLL
     int efd = epoll_create(count);
     if (efd < 0) {
@@ -27,8 +29,9 @@ struct poolhd *init_pool(int count)
     pool->pevents = malloc(sizeof(*pool->pevents) * count);
     pool->links = malloc(sizeof(*pool->links) * count);
     pool->items = malloc(sizeof(*pool->items) * count);
-    
+
     if (!pool->pevents || !pool->links || !pool->items) {
+        uniperror("init pool");
         destroy_pool(pool);
         return 0;
     }
@@ -45,19 +48,21 @@ struct eval *add_event(struct poolhd *pool, enum eid type,
 {
     assert(fd > 0);
     if (pool->count >= pool->max) {
+        LOG(LOG_E, "add_event: pool is full\n");
         return 0;
     }
     struct eval *val = pool->links[pool->count];
     memset(val, 0, sizeof(*val));
-    
+
     val->mod_iter = pool->iters;
     val->fd = fd;
     val->index = pool->count;
     val->type = type;
-    
+
     #ifndef NOEPOLL
     struct epoll_event ev = { .events = EPOLLRDHUP | e, .data = {val} };
     if (epoll_ctl(pool->efd, EPOLL_CTL_ADD, fd, &ev)) {
+        uniperror("add event");
         return 0;
     }
     #else
@@ -67,7 +72,7 @@ struct eval *add_event(struct poolhd *pool, enum eid type,
     pfd->events = POLLRDHUP | e;
     pfd->revents = 0;
     #endif
-    
+
     pool->count++;
     return val;
 }

--- a/error.h
+++ b/error.h
@@ -11,6 +11,8 @@
     #include <android/log.h>
 #endif
 
+#include "params.h"
+
 #ifdef _WIN32
 #define get_e() \
     unie(WSAGetLastError())

--- a/proxy.c
+++ b/proxy.c
@@ -608,6 +608,7 @@ static inline int on_accept(struct poolhd *pool, struct eval *val)
             continue;
         }
         if (!(rval = add_event(pool, EV_REQUEST, c, POLLIN))) {
+            LOG(LOG_E, "add_event: pool is full\n");
             close(c);
             continue;
         }

--- a/proxy.c
+++ b/proxy.c
@@ -614,6 +614,7 @@ static inline int on_accept(struct poolhd *pool, struct eval *val)
         rval->in6 = client.in6;
         #ifdef __linux__
         if (params.transparent && transp_conn(pool, rval) < 0) {
+            del_event(pool, rval);
             close(c);
             continue;
         }

--- a/proxy.c
+++ b/proxy.c
@@ -616,7 +616,6 @@ static inline int on_accept(struct poolhd *pool, struct eval *val)
         #ifdef __linux__
         if (params.transparent && transp_conn(pool, rval) < 0) {
             del_event(pool, rval);
-            close(c);
             continue;
         }
         #endif

--- a/proxy.c
+++ b/proxy.c
@@ -608,7 +608,6 @@ static inline int on_accept(struct poolhd *pool, struct eval *val)
             continue;
         }
         if (!(rval = add_event(pool, EV_REQUEST, c, POLLIN))) {
-            LOG(LOG_E, "add_event: pool is full\n");
             close(c);
             continue;
         }
@@ -905,12 +904,10 @@ int event_loop(int srvfd)
     
     struct poolhd *pool = init_pool(params.max_open * 2 + 1);
     if (!pool) {
-        uniperror("init pool");
         close(srvfd);
         return -1;
     }
     if (!add_event(pool, EV_ACCEPT, srvfd, POLLIN)) {
-        uniperror("add event");
         destroy_pool(pool);
         close(srvfd);
         return -1;


### PR DESCRIPTION
1. No a reason to keep an event with closed socket.
2. I believe it is useful to know when the pool is full.