### PR TITLE
Separate options from service, add system service

### DIFF
--- a/dist/linux/README.md
+++ b/dist/linux/README.md
@@ -9,16 +9,30 @@ sudo make install
 
 ## Systemd Service (optional)
 
-Copy and enable the service:
+You can configure the program to run as systemd service, user- or system-wide (only one at a time).
+
+### As user service:
 
 ```sh
 cp byedpi.service ~/.config/systemd/user/
-systemctl --user daemon-reload
-systemctl --user enable byedpi.service
-systemctl --user start byedpi.service
+cp byedpi.conf ~/.config/
+systemctl --user enable --now byedpi.service
 ```
 
 You should see the service now marked as "active":
 ```sh
 systemctl --user status byedpi.service
+```
+
+### As system service:
+
+```sh
+sudo cp byedpi.service /etc/systemd/system/
+sudo cp byedpi.conf /etc/
+sudo systemctl enable --now byedpi.service
+```
+
+You should see the service now marked as "active":
+```sh
+systemctl status byedpi.service
 ```

--- a/dist/linux/byedpi.conf
+++ b/dist/linux/byedpi.conf
@@ -1,0 +1,8 @@
+# More options and their descriptions can be found here:
+# https://github.com/hufrea/byedpi/blob/main/README.md
+# 
+# By default, ciadpi listens on all interfaces, 
+# a specific one can be specified via "--ip 127.0.0.1".
+
+# Put your options here
+BYEDPI_OPTIONS="--split 1 --disorder 3+s --mod-http=h,d --auto=torst --tlsrec 1+s"

--- a/dist/linux/byedpi.service
+++ b/dist/linux/byedpi.service
@@ -1,12 +1,17 @@
 [Unit]
-Description=byedpi
+Description=ByeDPI
 Documentation=https://github.com/hufrea/byedpi
+Wants=network-online.target
+After=network-online.target nss-lookup.target
 
 [Service]
-ExecStart=ciadpi --split 1 --disorder 3+s --mod-http=h,d --auto=torst --tlsrec 1+s
+NoNewPrivileges=yes
+StandardOutput=null
+StandardError=journal
+EnvironmentFile=-/etc/byedpi.conf
+EnvironmentFile=-%h/.config/byedpi.conf
+ExecStart=ciadpi $BYEDPI_OPTIONS
 TimeoutStopSec=5s
-LimitNOFILE=1048576
-LimitNPROC=512
 PrivateTmp=true
 ProtectSystem=full
 


### PR DESCRIPTION
Moved the keys/options to a separate file, added instructions for installing the system service. I am not an expert in systemd, so I did not remove/correct the existing fields. I checked both methods, and user- and system-wide both work properly.