### PR TITLE
Fix send_fake implementation conditional

### DIFF
--- a/desync.c
+++ b/desync.c
@@ -249,7 +249,9 @@ ssize_t send_fake(int sfd, char *buffer,
     close(fds[1]);
     return len;
 }
-#else
+#endif
+
+#ifdef _WIN32
 OVERLAPPED ov = {};
 
 ssize_t send_fake(int sfd, char *buffer,


### PR DESCRIPTION
Because of `#else` from `#ifdef __linux__` for send_fake, windows code gets included when system is anything but Linux. 
This breaks building on BSD systems.