### PR TITLE
Another auto+desync realization

### DIFF
--- a/conev.h
+++ b/conev.h
@@ -37,9 +37,7 @@ enum eid {
     EV_CONNECT,
     EV_IGNORE,
     EV_TUNNEL,
-    EV_PRE_TUNNEL,
-    EV_UDP_TUNNEL,
-    EV_DESYNC
+    EV_UDP_TUNNEL
 };
 
 #define FLAG_S4 1
@@ -53,9 +51,7 @@ char *eid_name[] = {
     "EV_CONNECT",
     "EV_IGNORE",
     "EV_TUNNEL",
-    "EV_PRE_TUNNEL",
-    "EV_UDP_TUNNEL",
-    "EV_DESYNC"
+    "EV_UDP_TUNNEL"
 };
 #endif
 
@@ -63,6 +59,7 @@ struct buffer {
     ssize_t size;
     int offset;
     char *data;
+    char locked;
 };
 
 struct eval {

--- a/conev.h
+++ b/conev.h
@@ -2,6 +2,7 @@
 #define CONEV_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #ifndef __linux__
     #define NOEPOLL
@@ -56,10 +57,10 @@ char *eid_name[] = {
 #endif
 
 struct buffer {
-    ssize_t size;
-    int offset;
+    size_t size;
+    unsigned int offset;
     char *data;
-    char locked;
+    bool locked;
 };
 
 struct eval {
@@ -75,11 +76,11 @@ struct eval {
         struct sockaddr_in6 in6;
     };
     ssize_t recv_count;
+    ssize_t round_sent;
     unsigned int round_count;
-    char last_round;
     int attempt;
-    char cache;
-    char mark; //
+    bool cache;
+    bool mark; //
 };
 
 struct poolhd {

--- a/conev.h
+++ b/conev.h
@@ -38,7 +38,8 @@ enum eid {
     EV_CONNECT,
     EV_IGNORE,
     EV_TUNNEL,
-    EV_UDP_TUNNEL
+    EV_UDP_TUNNEL,
+    EV_FIRST_TUNNEL
 };
 
 #define FLAG_S4 1
@@ -52,7 +53,8 @@ char *eid_name[] = {
     "EV_CONNECT",
     "EV_IGNORE",
     "EV_TUNNEL",
-    "EV_UDP_TUNNEL"
+    "EV_UDP_TUNNEL",
+    "EV_FIRST_TUNNEL"
 };
 #endif
 
@@ -60,7 +62,6 @@ struct buffer {
     size_t size;
     unsigned int offset;
     char *data;
-    bool locked;
 };
 
 struct eval {

--- a/desync.c
+++ b/desync.c
@@ -489,7 +489,7 @@ ssize_t desync(int sfd, char *buffer, size_t bfsize,
         return -1;
     }
     #endif
-    long lp = offset;
+    long lp = 0;
     struct part part;
     int i = 0, r = 0;
     
@@ -504,6 +504,7 @@ ssize_t desync(int sfd, char *buffer, size_t bfsize,
         pos += part.s * (part.r - r);
         
         if (!(part.flag & OFFSET_START) && offset && pos <= offset) {
+            LOG(LOG_S, "offset: %zd, skip\n", offset);
             continue;
         }
         if (pos < 0 || pos > n || pos < lp) {

--- a/extend.c
+++ b/extend.c
@@ -367,8 +367,11 @@ ssize_t tcp_send_hook(struct poolhd *pool, struct eval *remote,
     int m = client->attempt;
     LOG((m ? LOG_S : LOG_L), "desync params index: %d\n", m);
     
+    ssize_t offset = client->round_sent + client->buff.offset;
+    if (!offset && remote->round_count) offset = -1;
+    
     sn = desync(remote->fd, buffer, bfsize, n,
-        0, (struct sockaddr *)&remote->in6, m);
+        offset, (struct sockaddr *)&remote->in6, m);
     return sn;
 }
 

--- a/extend.c
+++ b/extend.c
@@ -166,6 +166,7 @@ static int reconnect(struct poolhd *pool, struct eval *val, int m)
     client->attempt = m;
     client->cache = 1;
     client->buff.offset = 0;
+    client->round_sent = 0;
     return 0;
 }
 
@@ -367,7 +368,7 @@ ssize_t tcp_send_hook(struct poolhd *pool, struct eval *remote,
     int m = client->attempt;
     LOG((m ? LOG_S : LOG_L), "desync params index: %d\n", m);
     
-    ssize_t offset = client->round_sent + client->buff.offset;
+    ssize_t offset = client->round_sent;
     if (!offset && remote->round_count) offset = -1;
     
     sn = desync(remote->fd, buffer, bfsize, n,

--- a/extend.c
+++ b/extend.c
@@ -452,7 +452,7 @@ ssize_t tcp_send_hook(struct eval *remote,
         return -1;
     }
     int m = client->attempt;
-    LOG((m ? LOG_S : LOG_L), "desync params index: %d\n", m);
+    LOG((m ? LOG_S : LOG_L), "desync TCP, m=%d\n", m);
     
     ssize_t offset = client->round_sent;
     if (!offset && remote->round_count) offset = -1;
@@ -508,7 +508,9 @@ ssize_t tcp_recv_hook(struct poolhd *pool, struct eval *val,
 ssize_t udp_hook(struct eval *val, 
         char *buffer, size_t bfsize, ssize_t n, struct sockaddr_ina *dst)
 {
-    if (val->round_count > params.repeats) {
+    struct eval *pair = val->pair->pair;
+    
+    if (pair->round_count > params.repeats) {
         return send(val->fd, buffer, n, 0);
     }
     int m = val->attempt;
@@ -526,6 +528,7 @@ ssize_t udp_hook(struct eval *val,
         }
         val->attempt = m;
     }
+    LOG(LOG_S, "desync UDP, m=%d\n", m);
     return desync_udp(val->fd, buffer, bfsize, n, &dst->sa, m);
 }
 

--- a/extend.h
+++ b/extend.h
@@ -10,18 +10,14 @@ int socket_mod(int fd, struct sockaddr *dst);
 int connect_hook(struct poolhd *pool, struct eval *val, 
         struct sockaddr_ina *dst, int next);
         
-int on_tunnel_check(struct poolhd *pool, struct eval *val,
-        char *buffer, size_t bfsize, int out);
-
-int on_desync(struct poolhd *pool, struct eval *val,
-        char *buffer, size_t bfsize, int out);
-
+ssize_t tcp_send_hook(struct poolhd *pool, struct eval *val,
+        char *buffer, size_t bfsize, ssize_t n);
+        
+ssize_t tcp_recv_hook(struct poolhd *pool, struct eval *val,
+        char *buffer, size_t bfsize);
+        
 ssize_t udp_hook(struct eval *val, 
         char *buffer, size_t bfsize, ssize_t n, struct sockaddr_ina *dst);
-
-int on_torst(struct poolhd *pool, struct eval *val);
-
-int on_fin(struct poolhd *pool, struct eval *val);
 
 #ifdef __linux__
 int protect(int conn_fd, const char *path);

--- a/extend.h
+++ b/extend.h
@@ -10,7 +10,7 @@ int socket_mod(int fd, struct sockaddr *dst);
 int connect_hook(struct poolhd *pool, struct eval *val, 
         struct sockaddr_ina *dst, int next);
         
-ssize_t tcp_send_hook(struct poolhd *pool, struct eval *val,
+ssize_t tcp_send_hook(struct eval *val,
         char *buffer, size_t bfsize, ssize_t n);
         
 ssize_t tcp_recv_hook(struct poolhd *pool, struct eval *val,
@@ -19,6 +19,9 @@ ssize_t tcp_recv_hook(struct poolhd *pool, struct eval *val,
 ssize_t udp_hook(struct eval *val, 
         char *buffer, size_t bfsize, ssize_t n, struct sockaddr_ina *dst);
 
+int on_first_tunnel(struct poolhd *pool,
+        struct eval *val, char *buffer, ssize_t bfsize, int etype);
+        
 #ifdef __linux__
 int protect(int conn_fd, const char *path);
 #else

--- a/main.c
+++ b/main.c
@@ -54,8 +54,9 @@ struct params params = {
     .laddr = {
         .sin6_family = AF_INET
     },
+    .repeats = 1,
     .debug = 0,
-    .auto_level = 0
+    .auto_level = -1
 };
 
 
@@ -80,6 +81,7 @@ const char help_text[] = {
     "                              Detect: torst,redirect,ssl_err,none\n"
     "    -L, --auto-mode <0|1>     1 - handle trigger after several packets\n"
     "    -u, --cache-ttl <sec>     Lifetime of cached desync params for IP\n"
+    "    -R, --repeats <num>       Number of requests to which desync will be applied\n"
     #ifdef TIMEOUT_SUPPORT
     "    -T, --timeout <sec>       Timeout waiting for response, after which trigger auto\n"
     #endif
@@ -134,6 +136,7 @@ const struct option options[] = {
     #endif
     {"auto",          1, 0, 'A'},
     {"auto-mode",     1, 0, 'L'},
+    {"repeats",       1, 0, 'R'},
     {"cache-ttl",     1, 0, 'u'},
     #ifdef TIMEOUT_SUPPORT
     {"timeout",       1, 0, 'T'},
@@ -616,6 +619,14 @@ int main(int argc, char **argv)
                 params.auto_level = val;
             break;
             
+        case 'R':
+            val = strtol(optarg, &end, 0);
+            if (val < 1 || val > INT_MAX || *end)
+                invalid = 1;
+            else
+                params.repeats = val;
+            break;
+            
         case 'A':
             if (!(dp->hosts || dp->proto || dp->pf[0] || dp->detect)) {
                 all_limited = 0;
@@ -647,6 +658,9 @@ int main(int argc, char **argv)
                 }
                 end = strchr(end, ',');
                 if (end) end++;
+            }
+            if (dp->detect && params.auto_level == -1) {
+                params.auto_level = 0;
             }
             break;
             

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@ struct params params = {
     },
     .repeats = 1,
     .debug = 0,
-    .auto_level = -1
+    .auto_level = AUTO_NOBUFF
 };
 
 
@@ -659,8 +659,8 @@ int main(int argc, char **argv)
                 end = strchr(end, ',');
                 if (end) end++;
             }
-            if (dp->detect && params.auto_level == -1) {
-                params.auto_level = 0;
+            if (dp->detect && params.auto_level == AUTO_NOBUFF) {
+                params.auto_level = AUTO_NOSAVE;
             }
             break;
             

--- a/main.c
+++ b/main.c
@@ -421,7 +421,8 @@ int parse_offset(struct part *part, const char *str)
             case 'r':
                 part->flag |= OFFSET_RAND;
                 break;
-            case 's':;
+            case 's':
+                part->flag |= OFFSET_START;
         }
     }
     part->pos = val;

--- a/main.c
+++ b/main.c
@@ -54,7 +54,6 @@ struct params params = {
     .laddr = {
         .sin6_family = AF_INET
     },
-    .repeats = 1,
     .debug = 0,
     .auto_level = AUTO_NOBUFF
 };
@@ -81,13 +80,13 @@ const char help_text[] = {
     "                              Detect: torst,redirect,ssl_err,none\n"
     "    -L, --auto-mode <0|1>     1 - handle trigger after several packets\n"
     "    -u, --cache-ttl <sec>     Lifetime of cached desync params for IP\n"
-    "    -R, --repeats <num>       Number of requests to which desync will be applied\n"
     #ifdef TIMEOUT_SUPPORT
     "    -T, --timeout <sec>       Timeout waiting for response, after which trigger auto\n"
     #endif
     "    -K, --proto <t,h,u>       Protocol whitelist: tls,http,udp\n"
     "    -H, --hosts <file|:str>   Hosts whitelist, filename or :string\n"
     "    -V, --pf <port[-portr]>   Ports range whitelist\n"
+    "    -R, --round <num[-numr>   Number of request to which desync will be applied\n"
     "    -s, --split <pos_t>       Position format: offset[:repeats:skip][+flag1[flag2]]\n"
     "                              Flags: +s - SNI offset, +h - HTTP host offset\n"
     "                              Additional flags: +e - end, +m - middle, +r - random\n"
@@ -136,7 +135,6 @@ const struct option options[] = {
     #endif
     {"auto",          1, 0, 'A'},
     {"auto-mode",     1, 0, 'L'},
-    {"repeats",       1, 0, 'R'},
     {"cache-ttl",     1, 0, 'u'},
     #ifdef TIMEOUT_SUPPORT
     {"timeout",       1, 0, 'T'},
@@ -144,6 +142,7 @@ const struct option options[] = {
     {"proto",         1, 0, 'K'},
     {"hosts",         1, 0, 'H'},
     {"pf",            1, 0, 'V'},
+    {"repeats",       1, 0, 'R'},
     {"split",         1, 0, 's'},
     {"disorder",      1, 0, 'd'},
     {"oob",           1, 0, 'o'},
@@ -620,14 +619,6 @@ int main(int argc, char **argv)
                 params.auto_level = val;
             break;
             
-        case 'R':
-            val = strtol(optarg, &end, 0);
-            if (val < 1 || val > INT_MAX || *end)
-                invalid = 1;
-            else
-                params.repeats = val;
-            break;
-            
         case 'A':
             if (!(dp->hosts || dp->proto || dp->pf[0] || dp->detect)) {
                 all_limited = 0;
@@ -878,6 +869,24 @@ int main(int argc, char **argv)
                     invalid = 1;
                 else
                     dp->pf[1] = htons(val);
+            }
+            break;
+            
+        case 'R':
+            val = strtol(optarg, &end, 0);
+            if (val <= 0 || val > INT_MAX)
+                invalid = 1;
+            else {
+                dp->rounds[0] = val;
+                if (*end == '-') {
+                    val = strtol(end + 1, &end, 0);
+                    if (val <= 0 || val > INT_MAX)
+                        invalid = 1;
+                }
+                if (*end)
+                    invalid = 1;
+                else
+                    dp->rounds[1] = val;
             }
             break;
             

--- a/params.h
+++ b/params.h
@@ -26,6 +26,7 @@
 #define OFFSET_RAND 4
 #define OFFSET_SNI 8
 #define OFFSET_HOST 16
+#define OFFSET_START 32
 
 #define DETECT_HTTP_LOCAT 1
 #define DETECT_TLS_ERR 2

--- a/params.h
+++ b/params.h
@@ -114,6 +114,8 @@ struct params {
     struct mphdr *mempool;
     
     char *protect_path;
+    
+    int repeats;
 };
 
 extern struct params params;

--- a/params.h
+++ b/params.h
@@ -31,6 +31,9 @@
 #define DETECT_TLS_ERR 2
 #define DETECT_TORST 8
 
+#define AUTO_NOBUFF -1
+#define AUTO_NOSAVE 0
+
 enum demode {
     DESYNC_NONE,
     DESYNC_SPLIT,

--- a/params.h
+++ b/params.h
@@ -89,6 +89,7 @@ struct desync_params {
     int detect;
     struct mphdr *hosts;
     uint16_t pf[2];
+    int rounds[2];
     
     char *file_ptr;
     ssize_t file_size;
@@ -118,8 +119,6 @@ struct params {
     struct mphdr *mempool;
     
     char *protect_path;
-    
-    int repeats;
 };
 
 extern struct params params;

--- a/proxy.c
+++ b/proxy.c
@@ -686,13 +686,13 @@ int on_tunnel(struct poolhd *pool, struct eval *val,
             return -1;
         }
         val->recv_count += n;
-        if (!val->last_round) {
+        if (val->round_sent == 0) {
             val->round_count++;
-            val->last_round = 1;
-            pair->last_round = 0;
+            pair->round_sent = 0;
         }
         
         ssize_t sn = tcp_send_hook(pool, pair, buffer, bfsize, n);
+        val->round_sent += sn > 0 ? sn : 0;
         if (sn < n) {
             if (sn < 0) {
                 uniperror("send");

--- a/proxy.c
+++ b/proxy.c
@@ -746,6 +746,11 @@ int on_udp_tunnel(struct eval *val, char *buffer, size_t bfsize)
             return -1;
         }
         val->recv_count += n;
+        if (val->round_sent == 0) {
+            val->round_count++;
+            val->round_sent += n;
+            val->pair->round_sent = 0;
+        }
         ssize_t ns;
         
         if (val->flag == FLAG_CONN) {


### PR DESCRIPTION
Adds support for desync the entire stream. 
Minimizes memory usage if `--auto` is not used.
Most of the auto/desync logic has been rewritten and simplified.