### PR TITLE
Fix building .o files in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,26 @@ WIN_LDFLAGS = -lws2_32 -lmswsock
 SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
 WIN_SRC = win_service.c
 
+OBJ = $(SRC:.c=.o)
+WIN_OBJ = $(WIN_SRC:.c=.o)
+
 PREFIX := /usr/local
 INSTALL_DIR := $(DESTDIR)$(PREFIX)/bin/
 
-all: 
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(SRC) -o $(TARGET) $(LDFLAGS)
+all: $(TARGET)
 
-windows: 
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(SRC) $(WIN_SRC) -o $(TARGET).exe $(WIN_LDFLAGS)
+$(TARGET): $(OBJ)
+	$(CC) -o $(TARGET) $(OBJ) $(LDFLAGS)
+
+windows: $(OBJ) $(WIN_OBJ)
+	$(CC) -o $(TARGET).exe $(OBJ) $(WIN_OBJ) $(WIN_LDFLAGS)
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 
 clean:
 	rm -f $(TARGET) $(TARGET).exe $(OBJ) $(WIN_OBJ)
 
-install: all
+install: $(TARGET)
 	mkdir -p $(INSTALL_DIR)
 	install -m 755 $(TARGET) $(INSTALL_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-.POSIX:
 
 TARGET = ciadpi
 
@@ -6,7 +5,7 @@ CPPFLAGS = -D_DEFAULT_SOURCE
 CFLAGS += -I. -std=c99 -Wall -Wno-unused -O2
 WIN_LDFLAGS = -lws2_32 -lmswsock
 
-HEADERS = conev.h desync.h error.h extend.h kavl.h mpool.h packets.h params.h platform.h proxy.h win_service.h
+HEADERS = conev.h desync.h error.h extend.h kavl.h mpool.h packets.h params.h proxy.h win_service.h
 SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
 WIN_SRC = win_service.c
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
+.POSIX:
+
 TARGET = ciadpi
 
 CPPFLAGS = -D_DEFAULT_SOURCE
 CFLAGS += -I. -std=c99 -Wall -Wno-unused -O2
 WIN_LDFLAGS = -lws2_32 -lmswsock
 
+HEADERS = conev.h desync.h error.h extend.h kavl.h mpool.h packets.h params.h platform.h proxy.h win_service.h
 SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
 WIN_SRC = win_service.c
 
@@ -21,6 +24,7 @@ $(TARGET): $(OBJ)
 windows: $(OBJ) $(WIN_OBJ)
 	$(CC) -o $(TARGET).exe $(OBJ) $(WIN_OBJ) $(WIN_LDFLAGS)
 
+$(OBJ): $(HEADERS)
 .c.o:
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $<
 


### PR DESCRIPTION
I suppose the issue in #213, #216, and #228 is that current Makefile don't recompile object files after any header files changes.
This PR should fix that: all objects files always recompile on any header files changes from `$(HEADERS)`.

Tested with both GNU make and BSD make.