### PR TITLE
Исправления

### DIFF
--- a/desync.c
+++ b/desync.c
@@ -688,8 +688,7 @@ ssize_t desync_udp(int sfd, char *buffer,
             return -1;
         }
         for (int i = 0; i < dp->udp_fake_count; i++) {
-            ssize_t len = sendto(sfd, pkt.data, 
-                pkt.size, 0, dst, sizeof(struct sockaddr_in6));
+            ssize_t len = send(sfd, pkt.data, pkt.size, 0);
             if (len < 0) {
                 uniperror("send");
                 return -1;
@@ -699,6 +698,5 @@ ssize_t desync_udp(int sfd, char *buffer,
             return -1;
         }
     }
-    return sendto(sfd, buffer, n, 0, 
-        dst, sizeof(struct sockaddr_in6));
+    return send(sfd, buffer, n, 0);
 }

--- a/main.c
+++ b/main.c
@@ -105,15 +105,15 @@ static const char help_text[] = {
     "    -q, --disoob <pos_t>      Split and send reverse order as OOB data\n"
     #ifdef FAKE_SUPPORT
     "    -f, --fake <pos_t>        Split and send fake packet\n"
-    "    -t, --ttl <num>           TTL of fake packets, default 8\n"
     #ifdef __linux__
     "    -k, --ip-opt[=f|:str]     IP options of fake packets\n"
     "    -S, --md5sig              Add MD5 Signature option for fake packets\n"
     #endif
-    "    -O, --fake-offset <n>     Fake data start offset\n"
-    "    -l, --fake-data <f|:str>  Set custom fake packet\n"
     "    -n, --tls-sni <str>       Change SNI in fake ClientHello\n"
     #endif
+    "    -t, --ttl <num>           TTL of fake packets, default 8\n"
+    "    -O, --fake-offset <n>     Fake data start offset\n"
+    "    -l, --fake-data <f|:str>  Set custom fake packet\n"
     "    -e, --oob-data <char>     Set custom OOB data\n"
     "    -M, --mod-http <h,d,r>    Modify HTTP: hcsmix,dcsmix,rmspace\n"
     "    -r, --tlsrec <pos_t>      Make TLS record at position\n"
@@ -164,15 +164,15 @@ const struct option options[] = {
     {"disoob",        1, 0, 'q'},
     #ifdef FAKE_SUPPORT
     {"fake",          1, 0, 'f'},
-    {"ttl",           1, 0, 't'},
     #ifdef __linux__
     {"ip-opt",        2, 0, 'k'},
     {"md5sig",        0, 0, 'S'},
     #endif
-    {"fake-data",     1, 0, 'l'},
     {"tls-sni",       1, 0, 'n'},
-    {"fake-offset",   1, 0, 'O'},
     #endif
+    {"ttl",           1, 0, 't'},
+    {"fake-data",     1, 0, 'l'},
+    {"fake-offset",   1, 0, 'O'},
     {"oob-data",      1, 0, 'e'},
     {"mod-http",      1, 0, 'M'},
     {"tlsrec",        1, 0, 'r'},


### PR DESCRIPTION
Для UDP теперь используется вызов send вместо sendto, т.к. это вызывало проблемы на iOS (возвращался EISCONN). Вероятно, это происходит из-за [этого](https://github.com/hufrea/byedpi/blob/fc254d3debf88045a47c7658750b69634834075e/proxy.c#L775) вызова connect. Более того, в udp_hook send [уже есть](https://github.com/hufrea/byedpi/blob/main/extend.c#L573). Но я не уверен что должно происходить в случае если sin_port == 0.

Также разблокированы опции --ttl, --fake-offset и --fake-data, т.к. они могут использоваться для UDP fake и не зависят от поддержки TCP fake.