### PR TITLE
Fix CI by adding unconditional push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,3 +38,4 @@ jobs:
           tags: ${{steps.meta.outputs.tags}}
           labels: ${{steps.meta.outputs.labels}}
           platforms: linux/amd64,linux/arm64
+          push: true


### PR DESCRIPTION
I removed conditional push while simplifying CI and did not check the default. It slipped through the cracks during tests because I explicitly set push to false to prevent overwriting my images.