### PR TITLE
Custom DNS resolver and DNS-over-TLS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ CPPFLAGS = -D_DEFAULT_SOURCE
 CFLAGS += -I. -std=c99 -O2 -Wall -Wno-unused -Wextra -Wno-unused-parameter -pedantic
 WIN_LDFLAGS = -lws2_32 -lmswsock
 
-HEADERS = conev.h desync.h error.h extend.h kavl.h mpool.h packets.h params.h proxy.h win_service.h
-SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c
+HEADERS = conev.h desync.h error.h extend.h kavl.h mpool.h packets.h params.h proxy.h resolve.h ssl_compat.h win_service.h
+SRC = packets.c main.c conev.c proxy.c desync.c mpool.c extend.c resolve.c ssl_compat.c
 WIN_SRC = win_service.c
 
 OBJ = $(SRC:.c=.o)

--- a/main.c
+++ b/main.c
@@ -10,6 +10,8 @@
 #include "packets.h"
 #include "error.h"
 #include "conev.h"
+#include "resolve.h"
+#include "ssl_compat.h"
 
 #ifndef _WIN32
     #include <arpa/inet.h>
@@ -59,6 +61,7 @@ struct params params = {
     .laddr = {
         .in = { .sin_family = AF_INET }
     },
+    .dns_mode = 's',
     .debug = 0
 };
 
@@ -75,6 +78,11 @@ static const char help_text[] = {
     #endif
     "    -c, --max-conn <count>    Connection count limit, default 512\n"
     "    -N, --no-domain           Deny domain resolving\n"
+    "    -k, --dns-mode <mode>     DNS resolution mode: system(s),plain(p),dot(t)\n"
+    "                              Defaults to system\n"
+    "    -z, --dns <host[:port]>   DNS resolver address\n"
+    "                              Only applicable when DNS mode is not 'system'\n"
+    "                              Takes IP as host when DNS mode is 'plain' and hostname when DNS mode is 'dot'\n"
     "    -U, --no-udp              Deny UDP association\n"
     "    -I  --conn-ip <ip>        Connection binded IP, default ::\n"
     "    -b, --buf-size <size>     Buffer size, default 16384\n"
@@ -132,6 +140,8 @@ const struct option options[] = {
     {"pidfile",       1, 0, 'w'},
     #endif
     {"no-domain",     0, 0, 'N'},
+    {"dns-mode",     1, 0, 'k'},
+    {"dns",     1, 0, 'z'},
     {"no-ipv6",       0, 0, 'X'},
     {"no-udp",        0, 0, 'U'},
     {"http-connect",  0, 0, 'G'},
@@ -476,6 +486,37 @@ int get_addr(const char *str, union sockaddr_u *addr)
 }
 
 
+int get_hostname(const char *str, union sockaddr_u *addr_out)
+{
+    uint16_t port = 0;
+    const char *e = 0;
+    const char *end = 0, *p = str;
+    
+    p = strchr(p, ':');
+    if (p && isdigit(p[1])) {
+        long val = strtol(p + 1, (char **)&end, 0);
+        if (val <= 0 || val > 0xffff || *end)
+            return -1;
+        else
+            port = htons(val);
+        if (!e) e = p;
+    }
+    if (!e) {
+        e = strchr(str, 0);
+    }
+    
+    if (resolve_system(str, e - str, addr_out) < 0) {
+        return -1;
+    }
+    
+    if (port) {
+        addr_out->in6.sin6_port = port;
+    }
+    
+    return e - str;
+}
+
+
 int get_default_ttl(void)
 {
     int orig_ttl = -1, fd;
@@ -688,6 +729,8 @@ int parse_args(int argc, char **argv)
     
     int curr_optind = 1;
     
+    char *dns_host = 0;
+    
     struct desync_params *dp = add_group(0);
     if (!dp) {
         return -1;
@@ -700,6 +743,20 @@ int parse_args(int argc, char **argv)
         
         case 'N':
             params.resolve = 0;
+            break;
+        case 'k':
+            if (strcmp(optarg, "system") == 0 || strcmp(optarg, "s") == 0) {
+                params.dns_mode = 's';
+            } else if (strcmp(optarg, "plain") == 0 || strcmp(optarg, "p") == 0) {
+                params.dns_mode = 'p';
+            } else if (strcmp(optarg, "dot") == 0 || strcmp(optarg, "t") == 0) {
+                params.dns_mode = 't';
+            } else {
+                invalid = 1;
+            }
+            break;
+        case 'z':
+            dns_host = optarg;
             break;
         case 'X':
             params.ipv6 = 0;
@@ -1221,6 +1278,58 @@ int parse_args(int argc, char **argv)
             return -1;
         }
     }
+    
+    switch (params.dns_mode) {
+        case 's':
+            if (dns_host) {
+                rez = 'z';
+                optarg = dns_host;
+                invalid = 1;
+            }
+            break;
+        case 'p':
+            if (dns_host == 0) {
+                rez = 'z';
+                optarg = "";
+                invalid = 1;
+                break;
+            }
+            if (get_addr(dns_host, &params.dns_addr) < 0) {
+                rez = 'z';
+                optarg = dns_host;
+                invalid = 1;
+                break;
+            }
+            if (!params.dns_addr.in6.sin6_port) {
+                params.dns_addr.in6.sin6_port = htons(53);
+            }
+            break;
+        case 't':
+            if (ssl_load() < 0) {
+                fprintf(stderr, "failed to load openssl that is required for DoT\n");
+                return -1;
+            }
+            if (dns_host == 0) {
+                rez = 'z';
+                optarg = "";
+                invalid = 1;
+                break;
+            }
+            int hostname_len = get_hostname(dns_host, &params.dns_addr);
+            if (hostname_len < 0) {
+                rez = 'z';
+                optarg = dns_host;
+                invalid = 1;
+                break;
+            }
+            if (!params.dns_addr.in.sin_port) {
+                params.dns_addr.in.sin_port = htons(853);
+            }
+            dns_host[hostname_len] = '\0';
+            params.dns_hostname = dns_host;
+            break;
+    }
+    
     if (invalid) {
         fprintf(stderr, "invalid value: -%c %s\n", rez, optarg);
         return -1;

--- a/main.c
+++ b/main.c
@@ -78,9 +78,9 @@ static const char help_text[] = {
     #endif
     "    -c, --max-conn <count>    Connection count limit, default 512\n"
     "    -N, --no-domain           Deny domain resolving\n"
-    "    -k, --dns-mode <mode>     DNS resolution mode: system(s),plain(p),dot(t)\n"
+    "    -k, --dns-mode <mode>     Domain resolution mode: system(s),plain(p),dot(t)\n"
     "                              Defaults to system\n"
-    "    -z, --dns <host[:port]>   DNS resolver address\n"
+    "    -z, --dns <host[:port]>   Nameserver address\n"
     "                              Only applicable when DNS mode is not 'system'\n"
     "                              Takes IP as host when DNS mode is 'plain' and hostname when DNS mode is 'dot'\n"
     "    -U, --no-udp              Deny UDP association\n"

--- a/params.h
+++ b/params.h
@@ -153,6 +153,9 @@ struct params {
     size_t bfsize;
     union sockaddr_u baddr;
     union sockaddr_u laddr;
+    char dns_mode;
+    union sockaddr_u dns_addr;
+    const char *dns_hostname;
     struct mphdr *mempool;
     
     const char *protect_path;

--- a/proxy.c
+++ b/proxy.c
@@ -12,6 +12,7 @@
 #include "extend.h"
 #include "error.h"
 #include "packets.h"
+#include "resolve.h"
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -136,33 +137,6 @@ static inline int nb_socket(int domain, int type)
 }
 
 
-static int resolve(const char *chost, int len, 
-        union sockaddr_u *addr, int type) 
-{
-    struct addrinfo hints = {0}, *res = 0;
-    
-    hints.ai_socktype = type;
-    hints.ai_flags = AI_ADDRCONFIG;
-    if (!params.resolve)
-        hints.ai_flags |= AI_NUMERICHOST;
-    hints.ai_family = params.ipv6 ? AF_UNSPEC : AF_INET;
-    
-    char host[len + 1];
-    host[len] = 0;
-    memcpy(host, chost, len);
-    
-    LOG(LOG_S, "resolve: %s\n", host);
-    
-    if (getaddrinfo(host, 0, &hints, &res) || !res) {
-        return -1;
-    }
-    memcpy(addr, res->ai_addr, SA_SIZE(res->ai_addr));
-    freeaddrinfo(res);
-    
-    return 0;
-}
-
-
 static int auth_socks5(int fd, const char *buffer, ssize_t n)
 {
     if (n <= 2 || (uint8_t)buffer[1] != (n - 2)) {
@@ -265,7 +239,7 @@ static int s4_get_addr(const char *buff,
         if (len < 3 || len > 255) {
             return -1;
         }
-        if (resolve(id_end + 1, len, dst, SOCK_STREAM)) {
+        if (resolve(id_end + 1, len, dst)) {
             LOG(LOG_E, "not resolved: %.*s\n", len, id_end + 1);
             return -1;
         }
@@ -279,8 +253,7 @@ static int s4_get_addr(const char *buff,
 }
 
 
-static int s5_get_addr(const char *buffer, 
-        size_t n, union sockaddr_u *addr, int type) 
+static int s5_get_addr(const char *buffer, size_t n, union sockaddr_u *addr) 
 {
     if (n < S_SIZE_MIN) {
         LOG(LOG_E, "ss: request too small\n");
@@ -306,7 +279,7 @@ static int s5_get_addr(const char *buffer,
                 return -S_ER_ATP;
             }
             if (r->dst.id.len < 3 || 
-                    resolve(r->dst.id.domain, r->dst.id.len, addr, type)) {
+                    resolve(r->dst.id.domain, r->dst.id.len, addr)) {
                 LOG(LOG_E, "not resolved: %.*s\n", r->dst.id.len, r->dst.id.domain);
                 return -S_ER_HOST;
             }
@@ -366,7 +339,7 @@ static int http_get_addr(
     if (host_len < 3 || host_len > 255) {
         return -1;
     }
-    if (resolve(host, host_len, dst, SOCK_STREAM)) {
+    if (resolve(host, host_len, dst)) {
         LOG(LOG_E, "not resolved: %.*s\n", host_len, host);
         return -1;
     }
@@ -787,7 +760,7 @@ int on_udp_tunnel(struct poolhd *pool, struct eval *val, int et)
             if (*(data + 2) != 0) { // frag
                 continue;
             }
-            int offs = s5_get_addr(data, n, &addr, SOCK_DGRAM);
+            int offs = s5_get_addr(data, n, &addr);
             if (offs < 0) {
                 LOG(LOG_E, "udp parse error\n");
                 return -1;
@@ -860,14 +833,14 @@ int on_request(struct poolhd *pool, struct eval *val, int et)
         int s5e = 0;
         switch (r->cmd) {
             case S_CMD_CONN:
-                s5e = s5_get_addr(buff->data, n, &dst, SOCK_STREAM);
+                s5e = s5_get_addr(buff->data, n, &dst);
                 if (s5e >= 0) {
                     error = connect_hook(pool, val, &dst, &on_connect);
                 }
                 break;
             case S_CMD_AUDP:
                 if (params.udp) {
-                    s5e = s5_get_addr(buff->data, n, &dst, SOCK_DGRAM);
+                    s5e = s5_get_addr(buff->data, n, &dst);
                     if (s5e >= 0) {
                         error = udp_associate(pool, val, &dst);
                     }
@@ -906,7 +879,7 @@ int on_request(struct poolhd *pool, struct eval *val, int et)
         error = connect_hook(pool, val, &dst, &on_connect);
     }
     else if (params.shadowsocks && *buff->data <= S_ATP_I6) {
-        int req_size = s5_get_addr(buff->data - 3, n + 3, &dst, SOCK_STREAM);
+        int req_size = s5_get_addr(buff->data - 3, n + 3, &dst);
         if (req_size < 0) {
             return -1;
         }

--- a/resolve.c
+++ b/resolve.c
@@ -188,7 +188,13 @@ int resolve_plain(const char *hostname, int len, union sockaddr_u *addr_out) {
     uint16_t qtype = htons(TYPE_A);
     uint16_t qclass = htons(CLASS_INET);
     
-    return resolve_plain_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    int res = resolve_plain_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    if (res < 0 && params.ipv6) {
+        qtype = htons(TYPE_AAAA);
+        res = resolve_plain_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    }
+    
+    return res;
 }
 
 int resolve_dot_inner(
@@ -343,7 +349,13 @@ int resolve_dot(const char *hostname, int len, union sockaddr_u *addr_out) {
     uint16_t qtype = htons(TYPE_A);
     uint16_t qclass = htons(CLASS_INET);
     
-    return resolve_dot_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    int res = resolve_dot_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    if (res < 0 && params.ipv6) {
+        qtype = htons(TYPE_AAAA);
+        res = resolve_dot_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+    }
+    
+    return res;
 }
 
 int resolve(const char *hostname, int len, union sockaddr_u *addr_out) {

--- a/resolve.c
+++ b/resolve.c
@@ -1,0 +1,600 @@
+#include "resolve.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <openssl/ssl.h>
+
+#ifdef _WIN32
+    #include <ws2tcpip.h>
+#else
+    #include <sys/types.h>
+    #include <sys/socket.h>
+    #include <netdb.h>
+#endif
+
+#include "params.h"
+#include "proxy.h"
+#include "error.h"
+#include "ssl_compat.h"
+
+#define FLAG_QR 15
+#define FLAG_OPCODE 14
+#define FLAG_AA 10
+#define FLAG_TC 9
+#define FLAG_RD 8
+#define FLAG_RA 7
+#define FLAG_Z 6
+#define FLAG_RCODE 3
+
+#define TYPE_A 1
+#define TYPE_CNAME 5
+#define TYPE_AAAA 28
+
+#define CLASS_INET 1
+
+struct header {
+	uint16_t id;
+	uint16_t flags;
+	uint16_t qdcount;
+	uint16_t ancount;
+	uint16_t nscount;
+	uint16_t arcount;
+};
+
+static SSL_CTX *ctx = NULL;
+
+int make_dns_request(
+    uint16_t id,
+    const uint8_t *qname,
+    int qname_len,
+    uint16_t qtype,
+    uint16_t qclass,
+    uint8_t **packet_out
+);
+
+int parse_dns_response(
+    uint8_t *buf,
+    int buf_len,
+    uint16_t id,
+    const char *debug_hostname,
+    int debug_hostname_len,
+    union sockaddr_u *addr_out,
+    uint8_t **cname_qname_out,
+    int *cname_len_out
+);
+
+int hostname_dot_to_dns(const char *src, int len, uint8_t *dst);
+
+int resolve_system(const char *hostname, int len, union sockaddr_u *addr_out) 
+{
+    struct addrinfo hints = {0}, *res = 0;
+    
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_ADDRCONFIG;
+    hints.ai_family = params.ipv6 ? AF_UNSPEC : AF_INET;
+    
+    char host[len + 1];
+    host[len] = 0;
+    memcpy(host, hostname, len);
+    
+    if (getaddrinfo(host, 0, &hints, &res) || !res) {
+        return -1;
+    }
+    memcpy(addr_out, res->ai_addr, SA_SIZE(res->ai_addr));
+    freeaddrinfo(res);
+    
+    return 0;
+}
+
+int resolve_plain_inner(
+    const uint8_t *qname,
+    int qname_len,
+    uint16_t qtype,
+    uint16_t qclass,
+    union sockaddr_u *addr_out,
+    const char* debug_hostname,
+    int debug_hostname_len,
+    int cname_rec
+) {
+    uint16_t id = rand();
+    
+    uint8_t *packet;
+    int packet_len = make_dns_request(id, qname, qname_len, qtype, qclass, &packet);
+    if (packet_len < 0) {
+        return -1;
+    }
+    
+    union sockaddr_u *ns_addr = &params.dns_addr;
+    
+    int fd = socket(ns_addr->sa.sa_family, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        free(packet);
+        return -1;
+    }
+    
+    struct timeval timeout = { .tv_sec = 5, .tv_usec = 0 };
+    
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        close(fd);
+        free(packet);
+        return -1;
+    }
+    
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0) {
+        close(fd);
+        free(packet);
+        return -1;
+    }
+    
+    if (connect(fd, &ns_addr->sa, sizeof(ns_addr->sa)) < 0) {
+        close(fd);
+        free(packet);
+        return -1;
+    }
+    
+    if (write(fd, packet, packet_len) < 0) {
+        close(fd);
+        free(packet);
+        return -1;
+    }
+    free(packet);
+    
+    uint8_t buf[512];
+    if (read(fd, buf, sizeof(buf)) <= 0) {
+        close(fd);
+        return -1;
+    }
+    close(fd);
+    
+    uint8_t *cname_qname = NULL;
+    int cname_len;
+    if (parse_dns_response(buf, sizeof(buf), id, debug_hostname, debug_hostname_len, addr_out, &cname_qname, &cname_len) < 0) {
+        return -1;
+    }
+    
+    if (cname_qname) {
+        if (cname_rec >= 10) {
+            LOG(LOG_S, "failed to resolve '%.*s': CNAME chain too long\n", debug_hostname_len, debug_hostname);
+            return -1;
+        }
+        
+        int res = resolve_plain_inner(
+            cname_qname,
+            cname_len,
+            qtype,
+            qclass,
+            addr_out,
+            debug_hostname,
+            debug_hostname_len,
+            cname_rec + 1
+        );
+        free(cname_qname);
+        
+        return res;
+    }
+    
+    return 0;
+}
+
+int resolve_plain(const char *hostname, int len, union sockaddr_u *addr_out) {
+    uint8_t qname[255];
+    int qname_len = hostname_dot_to_dns(hostname, len, qname);
+    
+    if (qname_len < 0) {
+        return -1;
+    }
+    
+    uint16_t qtype = htons(TYPE_A);
+    uint16_t qclass = htons(CLASS_INET);
+    
+    return resolve_plain_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+}
+
+int resolve_dot_inner(
+    const uint8_t *qname,
+    int qname_len,
+    uint16_t qtype,
+    uint16_t qclass,
+    union sockaddr_u *addr_out,
+    const char* debug_hostname,
+    int debug_hostname_len,
+    int cname_rec
+) {
+    uint16_t id = rand();
+    
+    uint8_t *packet;
+    int packet_len = make_dns_request(id, qname, qname_len, qtype, qclass, &packet);
+    if (packet_len < 0) {
+        return -1;
+    }
+    
+    int dot_packet_len = packet_len + 2;
+    uint8_t *dot_packet = malloc(dot_packet_len);
+    int packet_len_be = htons((uint16_t)packet_len);
+    memcpy(dot_packet, &packet_len_be, 2);
+    memcpy(dot_packet + 2, packet, packet_len);
+    free(packet);
+    
+    union sockaddr_u *ns_addr = &params.dns_addr;
+    
+    int fd = socket(ns_addr->sa.sa_family, SOCK_STREAM, 0);
+    if (fd < 0) {
+        free(dot_packet);
+        return -1;
+    }
+    
+    struct timeval timeout = { .tv_sec = 5, .tv_usec = 0 };
+    
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) < 0) {
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (connect(fd, &ns_addr->sa, sizeof(ns_addr->sa)) < 0) {
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (!ctx) {
+        ctx = SSL_CTX_new_fn(TLS_method_fn());
+    }
+    
+    SSL *ssl = SSL_new_fn(ctx);
+    if (!ssl) {
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (!SSL_set_fd_fn(ssl, fd)) {
+        SSL_free_fn(ssl);
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (SSL_connect_fn(ssl) < 1) {
+        SSL_free_fn(ssl);
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    
+    if (SSL_write_fn(ssl, dot_packet, dot_packet_len) <= 0) {
+        SSL_free_fn(ssl);
+        close(fd);
+        free(dot_packet);
+        return -1;
+    }
+    free(dot_packet);
+    
+    uint8_t len_buf[2];
+    int len_read = SSL_read_fn(ssl, len_buf, sizeof(len_buf));
+    if (len_read != 2) {
+        SSL_free_fn(ssl);
+        close(fd);
+        return -1;
+    }
+    
+    uint16_t recv_len = ntohs(*(uint16_t *)len_buf);
+    if (recv_len > 1024) {
+        SSL_free_fn(ssl);
+        close(fd);
+        return -1;
+    }
+    
+    uint8_t *buf = malloc(recv_len);
+    if (SSL_read_fn(ssl, buf, recv_len) <= 0) {
+        SSL_free_fn(ssl);
+        close(fd);
+        return -1;
+    }
+    SSL_free_fn(ssl);
+    close(fd);
+    
+    uint8_t *cname_qname = NULL;
+    int cname_len;
+    if (parse_dns_response(buf, recv_len, id, debug_hostname, debug_hostname_len, addr_out, &cname_qname, &cname_len) < 0) {
+        return -1;
+    }
+    free(buf);
+    
+    if (cname_qname) {
+        if (cname_rec >= 10) {
+            LOG(LOG_S, "failed to resolve '%.*s': CNAME chain too long\n", debug_hostname_len, debug_hostname);
+            return -1;
+        }
+        
+        int res = resolve_dot_inner(
+            cname_qname,
+            cname_len,
+            qtype,
+            qclass,
+            addr_out,
+            debug_hostname,
+            debug_hostname_len,
+            cname_rec + 1
+        );
+        free(cname_qname);
+        
+        return res;
+    }
+    
+    return 0;
+}
+
+int resolve_dot(const char *hostname, int len, union sockaddr_u *addr_out) {
+    uint8_t qname[255];
+    int qname_len = hostname_dot_to_dns(hostname, len, qname);
+    
+    if (qname_len < 0) {
+        return -1;
+    }
+    
+    uint16_t qtype = htons(TYPE_A);
+    uint16_t qclass = htons(CLASS_INET);
+    
+    return resolve_dot_inner(qname, qname_len, qtype, qclass, addr_out, hostname, len, 0);
+}
+
+int resolve(const char *hostname, int len, union sockaddr_u *addr_out) {
+    char hostname_term[len + 1];
+    memcpy(hostname_term, hostname, len);
+    hostname_term[len] = '\0';
+    
+    LOG(LOG_S, "resolve: %s\n", hostname_term);
+    
+    if (inet_pton(AF_INET, hostname_term, &addr_out->in.sin_addr) == 1) {
+        addr_out->in.sin_family = AF_INET;
+        return 0;
+    }
+    if (params.ipv6 && inet_pton(AF_INET6, hostname_term, &addr_out->in6.sin6_addr) == 1) {
+        addr_out->in6.sin6_family = AF_INET6;
+        return 0;
+    }
+    
+    if (!params.resolve) {
+        return -1;
+    }
+    
+    switch (params.dns_mode) {
+        case 's':
+            return resolve_system(hostname, len, addr_out);
+        case 'p':
+            return resolve_plain(hostname, len, addr_out);
+        case 't':
+            return resolve_dot(hostname, len, addr_out);
+    }
+    
+    return -1;
+}
+
+int make_dns_request(
+    uint16_t id,
+    const uint8_t *qname,
+    int qname_len,
+    uint16_t qtype,
+    uint16_t qclass,
+    uint8_t **packet_out
+) {
+    int packet_len = sizeof(struct header) + qname_len + 4; // qtype + qclass = 4
+    uint8_t *packet = malloc(packet_len);
+    if (!packet) {
+        return -1;
+    }
+    memset(packet, 0, packet_len);
+    
+    struct header *header = (struct header*)packet;
+    uint8_t *questions_start = packet + sizeof(struct header);
+    
+    header->id = id;
+    
+    uint16_t flags = 0;
+    flags |= 1 << FLAG_RD;
+    
+    header->flags = htons(flags);
+    header->qdcount = htons(1);
+    
+    memcpy(questions_start, qname, qname_len);
+    memcpy(questions_start + qname_len, &qtype, sizeof(qtype));
+    memcpy(questions_start + qname_len + sizeof(qtype), &qclass, sizeof(qclass));
+    
+    *packet_out = packet;
+    return packet_len;
+}
+
+int parse_dns_response(
+    uint8_t *buf,
+    int buf_len,
+    uint16_t id,
+    const char *debug_hostname,
+    int debug_hostname_len,
+    union sockaddr_u *addr_out,
+    uint8_t **cname_qname_out,
+    int *cname_len_out
+) {
+    struct header *header = (struct header*)buf;
+        
+    if (header->id != id) {
+        return -1;
+    }
+    
+    uint16_t flags = ntohs(header->flags);
+    if (((flags >> FLAG_QR) & 1) != 1) {
+        LOG(LOG_S, "failed to resolve '%.*s': nameserver returned invalid response\n", debug_hostname_len, debug_hostname);
+        return -1;
+    }
+    if (((flags >> FLAG_TC) & 1) != 0) {
+        LOG(LOG_S, "failed to resolve '%.*s': nameserver returned truncated response which is unsupported\n", debug_hostname_len, debug_hostname);
+        return -1;
+    }
+    if (((flags >> FLAG_RA) & 1) != 1) {
+        LOG(LOG_S, "failed to resolve '%.*s': nameserver doesn't support recursive queries\n", debug_hostname_len, debug_hostname);
+        return -1;
+    }
+    if ((flags & 0xf) != 0) {
+        LOG(LOG_S, "failed to resolve '%.*s': nameserver failed to resolve hostname\n", debug_hostname_len, debug_hostname);
+        return -1;
+    }
+    
+    uint16_t qdcount = ntohs(header->qdcount);
+    uint16_t ancount = ntohs(header->ancount);
+    if (qdcount != 1 || ancount < 1) {
+        LOG(LOG_S, "failed to resolve '%.*s': nameserver failed to resolve hostname\n", debug_hostname_len, debug_hostname);
+        return -1;
+    }
+    
+    uint8_t *ptr = buf + sizeof(struct header);
+    uint8_t *end = buf + buf_len;
+    
+    // skip question
+    if (*ptr >= 0xC0) {
+        ptr += 2;
+    } else {
+        while (ptr < end && *ptr != 0) {
+            ptr += *ptr + 1;
+        }
+        ptr++;
+    }
+    if (ptr + 4 > end) return -1;
+    ptr += 4;
+    
+    for (int i = 0; i < ancount; i++) {
+        if (ptr >= end) return -1;
+        
+        if (*ptr >= 0xC0) {
+            ptr += 2;
+        } else {
+            while (ptr < end && *ptr != 0) {
+                ptr += *ptr + 1;
+            }
+            if (ptr >= end) return -1;
+            ptr++;
+        }
+        
+        if (ptr + 10 > end) return -1;
+        
+        uint16_t type = ntohs(*(uint16_t*)ptr);
+        ptr += 2;
+        
+        uint16_t class = ntohs(*(uint16_t*)ptr);
+        ptr += 2;
+        
+        uint32_t ttl = ntohl(*(uint32_t*)ptr);
+        ptr += 4;
+        
+        uint16_t rdlength = ntohs(*(uint16_t*)ptr);
+        ptr += 2;
+        
+        if (ptr + rdlength > end) return -1;
+        
+        if (type == TYPE_A && class == CLASS_INET && rdlength == 4) {
+            addr_out->in.sin_family = AF_INET;
+            memcpy(&addr_out->in.sin_addr, ptr, 4);
+            return 0;
+        } else if (type == TYPE_AAAA && class == CLASS_INET && rdlength == 16 && params.ipv6) {
+            addr_out->in6.sin6_family = AF_INET6;
+            memcpy(&addr_out->in6.sin6_addr, ptr, 16);
+            return 0;
+        } else if (type == TYPE_CNAME && class == CLASS_INET) {
+            uint8_t *cname_qname = malloc(255);
+            uint8_t *cname_ptr = ptr;
+            uint8_t *cname_dst = cname_qname;
+            int cname_len = 0;
+            
+            while (cname_ptr < ptr + rdlength && *cname_ptr != 0) {
+                if (*cname_ptr >= 0xC0) {
+                    if (cname_ptr + 1 >= end) return -1;
+                    uint16_t offset = ntohs(*(uint16_t*)cname_ptr) & 0x3FFF;
+                    if (offset >= (ptr - buf)) return -1; // loop
+                    cname_ptr = buf + offset;
+                    continue;
+                }
+                
+                uint8_t label_len = *cname_ptr;
+                if (cname_len + label_len + 1 >= 255) return -1;
+                
+                memcpy(cname_dst, cname_ptr, label_len + 1);
+                cname_dst += label_len + 1;
+                cname_len += label_len + 1;
+                cname_ptr += label_len + 1;
+            }
+            
+            *cname_dst = 0;
+            cname_len++;
+            
+            *cname_qname_out = cname_qname;
+            *cname_len_out = cname_len;
+            
+            return 0;
+        }
+        
+        ptr += rdlength;
+    }
+    
+    LOG(LOG_S, "failed to resolve '%.*s': no A/AAAA/CNAME record in response\n", debug_hostname_len, debug_hostname);
+    return -1;
+}
+
+int hostname_dot_to_dns(const char *src, int len, uint8_t *dst) {
+    if (len <= 0 || len > 253 || !dst) {
+        return -1;
+    }
+    
+    if (src[0] == '.' || src[len - 1] == '.') {
+        return -1;
+    }
+    
+    int dns_hostname_len = 1;
+    int label_len = 0;
+    
+    for (int i = 0; i < len; i++) {
+        if (!isascii(src[i])) {
+            return -1;
+        }
+        
+        if (src[i] == '.') {
+            if (label_len == 0 || label_len > 63) {
+                return -1;
+            }
+            dns_hostname_len += 1 + label_len;
+            label_len = 0;
+        } else {
+            label_len++;
+        }
+    }
+    
+    if (label_len == 0 || label_len > 63) {
+        return -1;
+    }
+    dns_hostname_len += 1 + label_len;
+    
+    uint8_t *ptr = dst;
+    uint8_t *label_len_ptr = ptr++;
+    label_len = 0;
+    
+    for (int i = 0; i < len; i++) {
+        if (src[i] == '.') {
+            *label_len_ptr = (uint8_t)label_len;
+            label_len = 0;
+            label_len_ptr = ptr++;
+        } else {
+            *ptr++ = (uint8_t)src[i];
+            label_len++;
+        }
+    }
+    
+    *label_len_ptr = (uint8_t)label_len;
+    *ptr = 0;
+    
+    return dns_hostname_len;
+}

--- a/resolve.c
+++ b/resolve.c
@@ -318,6 +318,7 @@ int resolve_dot_inner(
     
     uint8_t *buf = malloc(recv_len);
     if (SSL_read_fn(ssl, buf, recv_len) <= 0) {
+        free(buf);
         SSL_free_fn(ssl);
         close(fd);
         return -1;
@@ -328,6 +329,7 @@ int resolve_dot_inner(
     uint8_t *cname_qname = NULL;
     int cname_len;
     if (parse_dns_response(buf, recv_len, id, debug_hostname, debug_hostname_len, addr_out, &cname_qname, &cname_len) < 0) {
+        free(buf);
         return -1;
     }
     free(buf);

--- a/resolve.c
+++ b/resolve.c
@@ -253,7 +253,13 @@ int resolve_dot_inner(
     
     if (!ctx) {
         ctx = SSL_CTX_new_fn(TLS_method_fn());
+        
+        #ifdef __ANDROID__
+        SSL_CTX_load_verify_locations_fn(ctx, NULL, "/system/etc/security/cacerts");
+        #else
         SSL_CTX_set_default_verify_paths_fn(ctx);
+        #endif
+        
         SSL_CTX_set_verify_fn(ctx, SSL_VERIFY_PEER, NULL);
     }
     

--- a/resolve.h
+++ b/resolve.h
@@ -1,0 +1,14 @@
+#ifndef RESOLVE_H
+#define RESOLVE_H
+
+#include "params.h"
+
+int resolve_system(const char *hostname, int len, union sockaddr_u *addr_out);
+
+int resolve_plain(const char *hostname, int len, union sockaddr_u *addr_out);
+
+int resolve_dot(const char *hostname, int len, union sockaddr_u *addr_out);
+
+int resolve(const char *hostname, int len, union sockaddr_u *addr_out);
+
+#endif

--- a/ssl_compat.c
+++ b/ssl_compat.c
@@ -1,0 +1,32 @@
+#include "ssl_compat.h"
+
+#include <openssl/ssl.h>
+#include <dlfcn.h>
+
+const SSL_METHOD *(*TLS_method_fn)(void) = NULL;
+SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*) = NULL;
+SSL *(*SSL_new_fn)(SSL_CTX*) = NULL;
+void *(*SSL_free_fn)(SSL*) = NULL;
+int (*SSL_set_fd_fn)(SSL*, int) = NULL;
+int (*SSL_connect_fn)(SSL*) = NULL;
+int (*SSL_read_fn)(SSL*, void*, int) = NULL;
+int (*SSL_write_fn)(SSL*, const void*, int) = NULL;
+
+int ssl_load(void) {
+    void *libssl = dlopen("libssl.so", RTLD_LAZY);
+    if (!libssl) {
+        fprintf(stderr, "%s\n", dlerror());
+        return -1;
+    }
+    
+    TLS_method_fn = dlsym(libssl, "TLS_method");
+    SSL_CTX_new_fn = dlsym(libssl, "SSL_CTX_new");
+    SSL_new_fn = dlsym(libssl, "SSL_new");
+    SSL_free_fn = dlsym(libssl, "SSL_free");
+    SSL_set_fd_fn = dlsym(libssl, "SSL_set_fd");
+    SSL_connect_fn = dlsym(libssl, "SSL_connect");
+    SSL_read_fn = dlsym(libssl, "SSL_read");
+    SSL_write_fn = dlsym(libssl, "SSL_write");
+    
+    return 0;
+}

--- a/ssl_compat.c
+++ b/ssl_compat.c
@@ -1,12 +1,16 @@
 #include "ssl_compat.h"
 
+#include <stdio.h>
 #include <openssl/ssl.h>
 #include <dlfcn.h>
 
 const SSL_METHOD *(*TLS_method_fn)(void) = NULL;
 SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*) = NULL;
+int (*SSL_CTX_set_default_verify_paths_fn)(SSL_CTX*) = NULL;
+void (*SSL_CTX_set_verify_fn)(SSL_CTX*, int, SSL_verify_cb) = NULL;
 SSL *(*SSL_new_fn)(SSL_CTX*) = NULL;
 void *(*SSL_free_fn)(SSL*) = NULL;
+int (*SSL_ctrl_fn)(SSL*, int, long, void*) = NULL;
 int (*SSL_set_fd_fn)(SSL*, int) = NULL;
 int (*SSL_connect_fn)(SSL*) = NULL;
 int (*SSL_read_fn)(SSL*, void*, int) = NULL;
@@ -21,8 +25,11 @@ int ssl_load(void) {
     
     TLS_method_fn = dlsym(libssl, "TLS_method");
     SSL_CTX_new_fn = dlsym(libssl, "SSL_CTX_new");
+    SSL_CTX_set_default_verify_paths_fn = dlsym(libssl, "SSL_CTX_set_default_verify_paths");
+    SSL_CTX_set_verify_fn = dlsym(libssl, "SSL_CTX_set_verify");
     SSL_new_fn = dlsym(libssl, "SSL_new");
     SSL_free_fn = dlsym(libssl, "SSL_free");
+    SSL_ctrl_fn = dlsym(libssl, "SSL_ctrl");
     SSL_set_fd_fn = dlsym(libssl, "SSL_set_fd");
     SSL_connect_fn = dlsym(libssl, "SSL_connect");
     SSL_read_fn = dlsym(libssl, "SSL_read");

--- a/ssl_compat.c
+++ b/ssl_compat.c
@@ -7,6 +7,7 @@
 const SSL_METHOD *(*TLS_method_fn)(void) = NULL;
 SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*) = NULL;
 int (*SSL_CTX_set_default_verify_paths_fn)(SSL_CTX*) = NULL;
+int (*SSL_CTX_load_verify_locations_fn)(SSL_CTX*, const char *CAfile, const char *CApath) = NULL;
 void (*SSL_CTX_set_verify_fn)(SSL_CTX*, int, SSL_verify_cb) = NULL;
 SSL *(*SSL_new_fn)(SSL_CTX*) = NULL;
 void *(*SSL_free_fn)(SSL*) = NULL;
@@ -26,6 +27,7 @@ int ssl_load(void) {
     TLS_method_fn = dlsym(libssl, "TLS_method");
     SSL_CTX_new_fn = dlsym(libssl, "SSL_CTX_new");
     SSL_CTX_set_default_verify_paths_fn = dlsym(libssl, "SSL_CTX_set_default_verify_paths");
+    SSL_CTX_load_verify_locations_fn = dlsym(libssl, "SSL_CTX_load_verify_locations");
     SSL_CTX_set_verify_fn = dlsym(libssl, "SSL_CTX_set_verify");
     SSL_new_fn = dlsym(libssl, "SSL_new");
     SSL_free_fn = dlsym(libssl, "SSL_free");

--- a/ssl_compat.h
+++ b/ssl_compat.h
@@ -1,0 +1,18 @@
+#ifndef SSL_COMPAT_H
+#define SSL_COMPAT_H
+
+#include <openssl/ssl.h>
+
+extern const SSL_METHOD *(*TLS_method_fn)(void);
+extern SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*);
+extern SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*);
+extern SSL *(*SSL_new_fn)(SSL_CTX*);
+extern void *(*SSL_free_fn)(SSL*);
+extern int (*SSL_set_fd_fn)(SSL*, int);
+extern int (*SSL_connect_fn)(SSL*);
+extern int (*SSL_read_fn)(SSL*, void*, int);
+extern int (*SSL_write_fn)(SSL*, const void*, int);
+
+int ssl_load(void);
+
+#endif

--- a/ssl_compat.h
+++ b/ssl_compat.h
@@ -5,9 +5,11 @@
 
 extern const SSL_METHOD *(*TLS_method_fn)(void);
 extern SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*);
-extern SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*);
+extern int (*SSL_CTX_set_default_verify_paths_fn)(SSL_CTX*);
+extern void (*SSL_CTX_set_verify_fn)(SSL_CTX*, int, SSL_verify_cb);
 extern SSL *(*SSL_new_fn)(SSL_CTX*);
 extern void *(*SSL_free_fn)(SSL*);
+extern int (*SSL_ctrl_fn)(SSL*, int, long, void*);
 extern int (*SSL_set_fd_fn)(SSL*, int);
 extern int (*SSL_connect_fn)(SSL*);
 extern int (*SSL_read_fn)(SSL*, void*, int);

--- a/ssl_compat.h
+++ b/ssl_compat.h
@@ -6,6 +6,7 @@
 extern const SSL_METHOD *(*TLS_method_fn)(void);
 extern SSL_CTX *(*SSL_CTX_new_fn)(const SSL_METHOD*);
 extern int (*SSL_CTX_set_default_verify_paths_fn)(SSL_CTX*);
+extern int (*SSL_CTX_load_verify_locations_fn)(SSL_CTX*, const char *CAfile, const char *CApath);
 extern void (*SSL_CTX_set_verify_fn)(SSL_CTX*, int, SSL_verify_cb);
 extern SSL *(*SSL_new_fn)(SSL_CTX*);
 extern void *(*SSL_free_fn)(SSL*);


### PR DESCRIPTION
Закрывает #293 

PR добавляет возможность указывать свой адрес DNS-сервера вместо использования системного
и использовать DNS-over-TLS вместо незашифрованных запросов.
Особенно полезно в текущих реалиях, когда ресурсы удаляют с DNS-серверов провайдеров.

При --dns-mode system (по умолчанию) используется системный резолвер
При --dns-mode plain используется адрес из --dns <ip[:port]>
При --dns-mode dot используется адрес из --dns <host[:port]>, требует наличие libssl в среде исполнения